### PR TITLE
Fix issues found while converting large (2,000+ page) wiki.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Although dokuwiki have no problem handling links that are broken over two lines,
 
 - Python3
 - Pandoc with multimarkdown (don't know if that is included by default)
+  - Pandoc 2.6+ is required for `dokuwiki` format support.
 
 # Usage
 

--- a/dokuwiki2wikijs.py
+++ b/dokuwiki2wikijs.py
@@ -15,6 +15,8 @@ tmp_prefix = os.path.join('/tmp', 'dokuwiki2wikijs')
 def pandoc(infile):
     result = subprocess.run(
         ["pandoc", "-f", "dokuwiki", "-t", "markdown_mmd", "--wrap=none", infile], stdout=subprocess.PIPE)
+    if len(result.stdout) == 0:
+        raise ValueError('Pandoc returned no output for file `%s`. This usually means that Pandoc encountered a syntax error in the input file and crashed. Try running `pandoc -f dokuwiki -t markdown_mmd --wrap=none AFFECTED_FILE` on the affected file to see if there is a syntax error.' % infile)
     return result.stdout.decode('utf-8')
 
 
@@ -176,7 +178,7 @@ def ensure_path_exists(path):
 
 
 def is_markdown(filename):
-    with open(filename) as f:
+    with open(filename, 'r', encoding='utf-8') as f:
         first_line = f.readline()
     return first_line[0] == '#'
 
@@ -245,7 +247,7 @@ def collect_and_convert_all_pages():
                 filename_with_md = filename_with_md.replace(
                     'start.md', 'home.md')
 
-            with open(filename_with_md, "w") as file:
+            with open(filename_with_md, "w", encoding="utf-8") as file:
                 file.writelines('\n'.join(lines))
 
             print(len(lines), "lines")


### PR DESCRIPTION
Use `utf-8` encoding - note that Dokuwiki has used utf-8 since 2017. Ref: https://www.dokuwiki.org/utf-8

Add note to README regarding minimum version Pandoc 2.6 required. (Note Ubuntu 20.04 LTS includes Pandoc 2.5 - one version too low!)